### PR TITLE
Fix build project and update dind version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rancher/dind:v0.2.0
+FROM rancher/dind:v0.3.0
 
 MAINTAINER Bill Maxwell "<bill@rancher.com>"
 

--- a/scripts/build-projects
+++ b/scripts/build-projects
@@ -17,7 +17,7 @@ build_projects()
             echo "building.. ${project}"
             wrap build
             if [ -n ${PROJECT_MAP["${project}_PACKAGE"]} ]; then
-                if [ ${PROJECT_MAP["${project}_PACKAGE"]} == "true" ]; then
+                if [ "${PROJECT_MAP["${project}_PACKAGE"]}" == "true" ]; then
                     wrap package
                 fi
             fi


### PR DESCRIPTION
This would not build host-api, the fix to build projects enables it.
Moving to docker 1.6 to try and speed up image pulls.
