### PR TITLE
Updated to switch rancher-compose to use latest versus beta/latest

### DIFF
--- a/scripts/common-vars
+++ b/scripts/common-vars
@@ -34,7 +34,7 @@
 : ${DEFAULT_CATTLE_CATALOG_EXECUTE:="true"}
 : ${DEFAULT_CATTLE_COMPOSE_EXECUTOR_EXECUTE:="true"}
 
-: ${CATTLE_RANCHER_COMPOSE_VERSION:="beta/latest"}
+: ${CATTLE_RANCHER_COMPOSE_VERSION:="latest"}
 : ${DEFAULT_CATTLE_RANCHER_COMPOSE_LINUX_URL:="https://releases.rancher.com/compose/${CATTLE_RANCHER_COMPOSE_VERSION}/rancher-compose-linux-amd64.tar.gz"}
 : ${DEFAULT_CATTLE_RANCHER_COMPOSE_DARWIN_URL:="https://releases.rancher.com/compose/${CATTLE_RANCHER_COMPOSE_VERSION}/rancher-compose-darwin-amd64.tar.gz"}
 : ${DEFAULT_CATTLE_RANCHER_COMPOSE_WINDOWS_URL:="https://releases.rancher.com/compose/${CATTLE_RANCHER_COMPOSE_VERSION}/rancher-compose-windows-386.zip"}


### PR DESCRIPTION
Currently, we're pointing to `releases.rancher.com/compose/beta/latest`, but we have only been updating `releases.rancher.com/compose/latest`.

This is to make the switch to latest. 
